### PR TITLE
feat: allows to unmarshal fields with unknown fields.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ generate-proto:
 	$(MAKE) -C ./tools/hypertrace/agent-config/tools/go-generator
 
 	@echo "Tidy generated modules."
-	@find $(PWD)/gen/go \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod::' | xargs -I {} bash -c 'cd {}; go mod tidy'
+	@find $(PWD)/gen/go \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod::' | xargs -I {} bash -c 'cd {}; go mod tidy -go=1.15'
 
 generate-env-vars: init-git-submodule ## Generates the ENV_VARS.md with all environment variables.
 	docker build -t hypertrace/agent-config/env-vars-generator tools/hypertrace/agent-config/tools/env-vars-generator

--- a/gen/go/go.mod
+++ b/gen/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/Traceableai/agent-config/gen/go
 
-go 1.16
+go 1.15
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/gen/go/v1/loader.go
+++ b/gen/go/v1/loader.go
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -60,6 +61,7 @@ func getInt32Env(name string) (int32, bool) {
 
 // loadFromFile loads the agent config from a file
 func loadFromFile(c *AgentConfig, filename string) error {
+	unmarshaler := &jsonpb.Unmarshaler{AllowUnknownFields: true}
 	switch ext := filepath.Ext(filename); ext {
 	case ".json":
 		freader, err := os.Open(filename)
@@ -70,7 +72,7 @@ func loadFromFile(c *AgentConfig, filename string) error {
 		// unmarshalers as the wrapped values aren't scalars but of type Message, hence they
 		// have object structure in json e.g. myBoolVal: {Value: true} instead of myBoolVal:true
 		// jsonpb is meant to solve this problem.
-		return jsonpb.Unmarshal(freader, c)
+		return unmarshaler.Unmarshal(freader, c)
 	case ".yaml", ".yml":
 		fcontent, err := ioutil.ReadFile(filename)
 		if err != nil {
@@ -83,7 +85,7 @@ func loadFromFile(c *AgentConfig, filename string) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse file %q: %v", filename, err)
 		}
-		return jsonpb.UnmarshalString(string(fcontentAsJSON), c)
+		return unmarshaler.Unmarshal(bytes.NewReader(fcontentAsJSON), c)
 	default:
 		return fmt.Errorf("unknown extension: %s", ext)
 	}

--- a/gen/go/v1/loader_test.go
+++ b/gen/go/v1/loader_test.go
@@ -61,3 +61,9 @@ func TestGetArrayStringEnv(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, []string{"a", "b"}, vals)
 }
+
+func TestLoadFromFileAcceptsUnknownFields(t *testing.T) {
+	cfg := &AgentConfig{}
+	err := loadFromFile(cfg, "./testdata/config.yaml")
+	assert.NoError(t, err)
+}

--- a/gen/go/v1/testdata/config.yaml
+++ b/gen/go/v1/testdata/config.yaml
@@ -1,0 +1,1 @@
+unknown_field_123: 456


### PR DESCRIPTION
## Description

This PR adds support for unmarshaling unknown fields. This is specially useful for cases like in https://github.com/Traceableai/goagent/blob/main/config/loaders.go#L23 where different configs are unmarshaled from the same file.

Related to https://github.com/hypertrace/agent-config/pull/71