### PR TITLE
ENGTAI-63250: switching filter timeout to timeout_ms instead of using durationpb

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -90,6 +90,6 @@ Agents can be configured using environment variables:
 | TA_GOAGENT_FILTER_THREAD_POOL_ENABLED | When `true` the thread pool will be activated |
 | TA_GOAGENT_FILTER_THREAD_POOL_NUM_WORKERS | Number of workers in the pool |
 | TA_GOAGENT_FILTER_THREAD_POOL_BUFFER_SIZE | Buffer size for handling spikes |
-| TA_GOAGENT_FILTER_THREAD_POOL_TIMEOUT | Specifies the maximum duration to wait for a free slot in the buffer. If this interval elapses without finding a free slot, the pending event will be discarded. Example values are: 10ms, 20s, 30m, 40h. |
+| TA_GOAGENT_FILTER_THREAD_POOL_TIMEOUT_MS | Specifies the maximum duration to wait for a free slot in the buffer in milliseconds. If this interval elapses without finding a free slot, the pending event will be discarded. |
 | TA_PARSER_CONFIG_GRAPHQL_ENABLED | When true, matching requests will be tried to be parsed with graphql schema. |
 | TA_PARSER_CONFIG_MAX_BODY_SIZE | Max body size which should be parsed |

--- a/gen/go/proto/v1/config.proto
+++ b/gen/go/proto/v1/config.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package ai.traceable.agent.config.v1;
 
-import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 option go_package = "github.com/Traceableai/agent-config/gen/go/v1";
@@ -422,8 +421,7 @@ message ThreadPool {
   google.protobuf.Int32Value num_workers = 2;
   // buffer size for handling spikes
   google.protobuf.Int32Value buffer_size = 3;
-  // specifies the maximum duration to wait for a free slot in the buffer.
+  // Specifies the maximum duration to wait for a free slot in the buffer in milliseconds.
   // If this interval elapses without finding a free slot, the pending event will be discarded.
-  // Example values are: 10ms, 20s, 30m, 40h.
-  google.protobuf.Duration timeout = 4;
+  google.protobuf.Int32Value timeout_ms = 4;
 }

--- a/gen/go/v1/config.pb.go
+++ b/gen/go/v1/config.pb.go
@@ -9,7 +9,6 @@ package v1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	reflect "reflect"
 	sync "sync"
@@ -2200,10 +2199,9 @@ type ThreadPool struct {
 	NumWorkers *wrapperspb.Int32Value `protobuf:"bytes,2,opt,name=num_workers,json=numWorkers,proto3" json:"num_workers,omitempty"`
 	// buffer size for handling spikes
 	BufferSize *wrapperspb.Int32Value `protobuf:"bytes,3,opt,name=buffer_size,json=bufferSize,proto3" json:"buffer_size,omitempty"`
-	// specifies the maximum duration to wait for a free slot in the buffer.
+	// Specifies the maximum duration to wait for a free slot in the buffer in milliseconds.
 	// If this interval elapses without finding a free slot, the pending event will be discarded.
-	// Example values are: 10ms, 20s, 30m, 40h.
-	Timeout       *durationpb.Duration `protobuf:"bytes,4,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	TimeoutMs     *wrapperspb.Int32Value `protobuf:"bytes,4,opt,name=timeout_ms,json=timeoutMs,proto3" json:"timeout_ms,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2259,9 +2257,9 @@ func (x *ThreadPool) GetBufferSize() *wrapperspb.Int32Value {
 	return nil
 }
 
-func (x *ThreadPool) GetTimeout() *durationpb.Duration {
+func (x *ThreadPool) GetTimeoutMs() *wrapperspb.Int32Value {
 	if x != nil {
-		return x.Timeout
+		return x.TimeoutMs
 	}
 	return nil
 }
@@ -2270,7 +2268,7 @@ var File_ai_traceable_agent_config_v1_config_proto protoreflect.FileDescriptor
 
 const file_ai_traceable_agent_config_v1_config_proto_rawDesc = "" +
 	"\n" +
-	")ai/traceable/agent/config/v1/config.proto\x12\x1cai.traceable.agent.config.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xf0\v\n" +
+	")ai/traceable/agent/config/v1/config.proto\x12\x1cai.traceable.agent.config.v1\x1a\x1egoogle/protobuf/wrappers.proto\"\xf0\v\n" +
 	"\vAgentConfig\x127\n" +
 	"\x03opa\x18\x01 \x01(\v2!.ai.traceable.agent.config.v1.OpaB\x02\x18\x01R\x03opa\x12U\n" +
 	"\x0fblocking_config\x18\x02 \x01(\v2,.ai.traceable.agent.config.v1.BlockingConfigR\x0eblockingConfig\x12;\n" +
@@ -2405,15 +2403,16 @@ const file_ai_traceable_agent_config_v1_config_proto_rawDesc = "" +
 	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled\"\x9c\x01\n" +
 	"\fParserConfig\x12K\n" +
 	"\agraphql\x18\x01 \x01(\v21.ai.traceable.agent.config.v1.GraphqlParserConfigR\agraphql\x12?\n" +
-	"\rmax_body_size\x18\x02 \x01(\v2\x1b.google.protobuf.Int32ValueR\vmaxBodySize\"\xf3\x01\n" +
+	"\rmax_body_size\x18\x02 \x01(\v2\x1b.google.protobuf.Int32ValueR\vmaxBodySize\"\xfa\x01\n" +
 	"\n" +
 	"ThreadPool\x124\n" +
 	"\aenabled\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\aenabled\x12<\n" +
 	"\vnum_workers\x18\x02 \x01(\v2\x1b.google.protobuf.Int32ValueR\n" +
 	"numWorkers\x12<\n" +
 	"\vbuffer_size\x18\x03 \x01(\v2\x1b.google.protobuf.Int32ValueR\n" +
-	"bufferSize\x123\n" +
-	"\atimeout\x18\x04 \x01(\v2\x19.google.protobuf.DurationR\atimeout*^\n" +
+	"bufferSize\x12:\n" +
+	"\n" +
+	"timeout_ms\x18\x04 \x01(\v2\x1b.google.protobuf.Int32ValueR\ttimeoutMs*^\n" +
 	"\aLogMode\x12\x18\n" +
 	"\x14LOG_MODE_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rLOG_MODE_NONE\x10\x01\x12\x13\n" +
@@ -2501,7 +2500,6 @@ var file_ai_traceable_agent_config_v1_config_proto_goTypes = []any{
 	(*wrapperspb.StringValue)(nil),    // 33: google.protobuf.StringValue
 	(*wrapperspb.Int32Value)(nil),     // 34: google.protobuf.Int32Value
 	(*wrapperspb.Int64Value)(nil),     // 35: google.protobuf.Int64Value
-	(*durationpb.Duration)(nil),       // 36: google.protobuf.Duration
 }
 var file_ai_traceable_agent_config_v1_config_proto_depIdxs = []int32{
 	8,   // 0: ai.traceable.agent.config.v1.AgentConfig.opa:type_name -> ai.traceable.agent.config.v1.Opa
@@ -2611,7 +2609,7 @@ var file_ai_traceable_agent_config_v1_config_proto_depIdxs = []int32{
 	32,  // 104: ai.traceable.agent.config.v1.ThreadPool.enabled:type_name -> google.protobuf.BoolValue
 	34,  // 105: ai.traceable.agent.config.v1.ThreadPool.num_workers:type_name -> google.protobuf.Int32Value
 	34,  // 106: ai.traceable.agent.config.v1.ThreadPool.buffer_size:type_name -> google.protobuf.Int32Value
-	36,  // 107: ai.traceable.agent.config.v1.ThreadPool.timeout:type_name -> google.protobuf.Duration
+	34,  // 107: ai.traceable.agent.config.v1.ThreadPool.timeout_ms:type_name -> google.protobuf.Int32Value
 	108, // [108:108] is the sub-list for method output_type
 	108, // [108:108] is the sub-list for method input_type
 	108, // [108:108] is the sub-list for extension type_name

--- a/gen/go/v1/config.pbloader.go
+++ b/gen/go/v1/config.pbloader.go
@@ -3,9 +3,6 @@
 package v1
 
 import (
-	"time"
-
-	duration "google.golang.org/protobuf/types/known/durationpb"
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -1135,12 +1132,14 @@ func (x *ThreadPool) loadFromEnv(prefix string, defaultValues *ThreadPool) {
 			x.BufferSize = &wrappers.Int32Value{Value: defaultValues.BufferSize.Value}
 		}
 	}
-	if val, ok := getDurationEnv(prefix + "TIMEOUT"); ok {
-		x.Timeout = duration.New(val)
-	} else if x.Timeout == nil {
-		x.Timeout = duration.New(time.Duration(0))
-		if defaultValues != nil && defaultValues.Timeout != nil {
-			x.Timeout = defaultValues.Timeout
+	if val, ok := getInt32Env(prefix + "TIMEOUT_MS"); ok {
+		x.TimeoutMs = &wrappers.Int32Value{Value: val}
+	} else if x.TimeoutMs == nil {
+		// when there is no value to set we still prefer to initialize the variable to avoid
+		// `nil` checks in the consumers.
+		x.TimeoutMs = new(wrappers.Int32Value)
+		if defaultValues != nil && defaultValues.TimeoutMs != nil {
+			x.TimeoutMs = &wrappers.Int32Value{Value: defaultValues.TimeoutMs.Value}
 		}
 	}
 }

--- a/proto/ai/traceable/agent/config/v1/config.proto
+++ b/proto/ai/traceable/agent/config/v1/config.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package ai.traceable.agent.config.v1;
 
-import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 option go_package = "github.com/Traceableai/agent-config/gen/go/v1";
@@ -422,8 +421,7 @@ message ThreadPool {
   google.protobuf.Int32Value num_workers = 2;
   // buffer size for handling spikes
   google.protobuf.Int32Value buffer_size = 3;
-  // specifies the maximum duration to wait for a free slot in the buffer.
+  // Specifies the maximum duration to wait for a free slot in the buffer in milliseconds.
   // If this interval elapses without finding a free slot, the pending event will be discarded.
-  // Example values are: 10ms, 20s, 30m, 40h.
-  google.protobuf.Duration timeout = 4;
+  google.protobuf.Int32Value timeout_ms = 4;
 }

--- a/tools/go-generator/cmd/generator/main.go
+++ b/tools/go-generator/cmd/generator/main.go
@@ -102,9 +102,7 @@ func generateLoaderForProtoFile(pkgFqpn string, pf pbparser.ProtoFile) ([]byte, 
 	c += fmt.Sprintf("package %s\n\n", pkgFqpn[strings.LastIndex(pkgFqpn, "/")+1:])
 	// even if we don't need this import, worth to add it as gofmt is going to remove it.
 	c += "import (\n"
-	c += "    \"time\"\n\n"
 	c += "    wrappers \"google.golang.org/protobuf/types/known/wrapperspb\"\n"
-	c += "    duration \"google.golang.org/protobuf/types/known/durationpb\"\n"
 	c += ")\n\n"
 	for _, m := range pf.Messages {
 		if shouldSkipOtherLanguageAgent(m.Name) {


### PR DESCRIPTION
There's a discrepancy in how durationpb marshals time and golang time package Marshals duration. Golang time package marshals time with units h, m, s, ms etc while duration protobuf will only marshal units of seconds, so milliseconds will be 0.001s which is gonna be confusing, hence moving to currently used style of taking input in milliseconds.
ref: https://github.com/protocolbuffers/protobuf-go/blob/v1.36.6/types/known/durationpb/duration.pb.go#L137